### PR TITLE
fixed chapter-level bug

### DIFF
--- a/catbook/regular_section.py
+++ b/catbook/regular_section.py
@@ -181,7 +181,7 @@ class RegularSection(Section):
         if self._is_chapter(line):
             self.metadata.CHAPTER = True
             line = line[1:]
-            self._add_upper_heading(line, 1)
+            self._add_upper_heading(line, 2)
 
     def _handle_book_if(self, line) -> None:
         if self._is_book(line):


### PR DESCRIPTION
The 2nd level, chapters, was calling the title creating method with a 1 when it should have been calling with a 2.